### PR TITLE
Seperate Expected Results and Actual Results

### DIFF
--- a/SuperUnit/SuperUnit.csproj
+++ b/SuperUnit/SuperUnit.csproj
@@ -7,4 +7,8 @@
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="xunit.assert" Version="2.6.2" />
+    </ItemGroup>
+
 </Project>

--- a/SuperUnit/TestPrinter.cs
+++ b/SuperUnit/TestPrinter.cs
@@ -55,7 +55,7 @@ public static class TestPrinter
             foreach (var testCaseResult in failingCaseResults)
             {
                 Console.WriteLine($"{result.Method.DeclaringType?.Name ?? "UndefinedType"}->{result.Method.Name}{testCaseResult.Parameters.Aggregate("(", (s, o) => s + o.ToTypedString() + ',').TrimEnd(',')})" +
-                                  $"failed, expected {testCaseResult.ExpectedResult}, got {testCaseResult.ActualResult}");
+                                  $"failed, expected {testCaseResult.ExpectedResult}, got {testCaseResult.MethodResult}");
             }
         }
 

--- a/SuperUnit/Tests/Results/ExpectedResult/ITestExpectedResult.cs
+++ b/SuperUnit/Tests/Results/ExpectedResult/ITestExpectedResult.cs
@@ -1,0 +1,8 @@
+using SuperUnit.Tests.Results.MethodResult;
+
+namespace SuperUnit.Tests.Results.ExpectedResult;
+
+public interface ITestExpectedResult
+{
+    public bool Test(IMethodResult actual);
+}

--- a/SuperUnit/Tests/Results/ExpectedResult/Return/EqualityTestExpectedResult.cs
+++ b/SuperUnit/Tests/Results/ExpectedResult/Return/EqualityTestExpectedResult.cs
@@ -1,0 +1,37 @@
+using SuperUnit.Tests.Results.MethodResult;
+using Xunit;
+using Xunit.Sdk;
+
+namespace SuperUnit.Tests.Results.ExpectedResult.Return;
+
+public class EqualityTestExpectedResult : ITestExpectedResult
+{
+    public object ExpectedResult { get; }
+
+    public EqualityTestExpectedResult(object expectedResult)
+    {
+        ExpectedResult = expectedResult;
+    }
+
+    public bool Test(IMethodResult actual)
+    {
+        if (actual is not ReturnValueMethodResult returnValueMethodResult)
+            return false;
+
+        try
+        {
+            Assert.Equal(ExpectedResult, returnValueMethodResult.ReturnValue);
+        }
+        catch (EqualException)
+        {
+            return false;
+        }
+        
+        return true;
+    }
+
+    public override string ToString()
+    {
+        return $"exactly {ExpectedResult.ToTypedString()} returned";
+    }
+}

--- a/SuperUnit/Tests/Results/ExpectedResult/Thrown/ExceptionThrownTestExpectedResult.cs
+++ b/SuperUnit/Tests/Results/ExpectedResult/Thrown/ExceptionThrownTestExpectedResult.cs
@@ -1,0 +1,37 @@
+using SuperUnit.Tests.Results.MethodResult;
+using Xunit;
+using Xunit.Sdk;
+
+namespace SuperUnit.Tests.Results.ExpectedResult.Thrown;
+
+public class ExceptionThrownTestExpectedResult : ITestExpectedResult
+{
+    public object ExpectedExceptionThrown { get; }
+
+    public ExceptionThrownTestExpectedResult(object expectedExceptionThrown)
+    {
+        ExpectedExceptionThrown = expectedExceptionThrown;
+    }
+    
+    public bool Test(IMethodResult actual)
+    {
+        if (actual is not ExceptionThrownMethodResult returnValueMethodResult)
+            return false;
+
+        try
+        {
+            Assert.Equal(ExpectedExceptionThrown, returnValueMethodResult.ThrownException);
+        }
+        catch (EqualException)
+        {
+            return false;
+        }
+        
+        return true;
+    }
+    
+    public override string ToString()
+    {
+        return $"exactly {ExpectedExceptionThrown.ToTypedString()} thrown";
+    }
+}

--- a/SuperUnit/Tests/Results/MethodResult/ExceptionThrownMethodResult.cs
+++ b/SuperUnit/Tests/Results/MethodResult/ExceptionThrownMethodResult.cs
@@ -2,21 +2,15 @@ namespace SuperUnit.Tests.Results.MethodResult;
 
 public class ExceptionThrownMethodResult : IMethodResult
 {
-    public Type ThrownExceptionType { get; }
+    public object ThrownException { get; }
     
-    public ExceptionThrownMethodResult(Type thrownExceptionType)
+    public ExceptionThrownMethodResult(object thrownException)
     {
-        ThrownExceptionType = thrownExceptionType;
+        ThrownException = thrownException;
     }
     
     public override string ToString()
     {
-        return $"{ThrownExceptionType.Name} thrown";
-    }
-
-    public bool Matches(IMethodResult other)
-    {
-        return other is ExceptionThrownMethodResult exceptionThrownMethodResult
-               && exceptionThrownMethodResult.ThrownExceptionType == ThrownExceptionType;
+        return $"{ThrownException.ToTypedString()} thrown";
     }
 }

--- a/SuperUnit/Tests/Results/MethodResult/IMethodResult.cs
+++ b/SuperUnit/Tests/Results/MethodResult/IMethodResult.cs
@@ -2,5 +2,4 @@ namespace SuperUnit.Tests.Results.MethodResult;
 
 public interface IMethodResult
 {
-    public bool Matches(IMethodResult other);
 }

--- a/SuperUnit/Tests/Results/MethodResult/ReturnValueMethodResult.cs
+++ b/SuperUnit/Tests/Results/MethodResult/ReturnValueMethodResult.cs
@@ -13,10 +13,4 @@ public class ReturnValueMethodResult : IMethodResult
     {
         return $"{ReturnValue.ToTypedString()} returned";
     }
-
-    public bool Matches(IMethodResult other)
-    {
-        return other is ReturnValueMethodResult returnValueMethodResult 
-               && returnValueMethodResult.ReturnValue.Equals(ReturnValue);
-    }
 }

--- a/SuperUnit/Tests/Results/TestCaseResult.cs
+++ b/SuperUnit/Tests/Results/TestCaseResult.cs
@@ -1,3 +1,4 @@
+using SuperUnit.Tests.Results.ExpectedResult;
 using SuperUnit.Tests.Results.MethodResult;
 
 namespace SuperUnit.Tests.Results;
@@ -6,22 +7,22 @@ public readonly struct TestCaseResult
 {
     public object[] Parameters { get; }
     
-    public IMethodResult ExpectedResult { get; }
+    public ITestExpectedResult ExpectedResult { get; }
     
-    public IMethodResult ActualResult { get; }
+    public IMethodResult MethodResult { get; }
 
-    public bool IsSuccessful => ExpectedResult.Matches(ActualResult);
+    public bool IsSuccessful => ExpectedResult.Test(MethodResult);
     
-    public TestCaseResult(object[] parameters, IMethodResult expectedResult, IMethodResult actualResult)
+    public TestCaseResult(object[] parameters, ITestExpectedResult expectedResult, IMethodResult methodResult)
     {
         Parameters = parameters;
-        
+
         ExpectedResult = expectedResult;
-        ActualResult = actualResult;
+        MethodResult = methodResult;
     }
 
     public override string ToString()
     {
-        return $"Expected: {ExpectedResult}, Got: {ActualResult}";
+        return $"Expected: {ExpectedResult}, Got: {MethodResult}";
     }
 }

--- a/SuperUnit/Tests/Test.cs
+++ b/SuperUnit/Tests/Test.cs
@@ -42,7 +42,7 @@ public readonly struct Test
             if (exceptionThrown != null)
             {
                 yield return new TestCaseResult(testCase.Parameters, testCase.ExpectedResult,
-                    new ExceptionThrownMethodResult(exceptionThrown.GetType()));
+                    new ExceptionThrownMethodResult(exceptionThrown));
             }
             else
             {

--- a/SuperUnit/Tests/TestCase.cs
+++ b/SuperUnit/Tests/TestCase.cs
@@ -1,3 +1,4 @@
+using SuperUnit.Tests.Results.ExpectedResult;
 using SuperUnit.Tests.Results.MethodResult;
 
 namespace SuperUnit.Tests;
@@ -8,9 +9,9 @@ public readonly struct TestCase
     
     public object[] Parameters { get; }
     
-    public IMethodResult ExpectedResult { get; }
+    public ITestExpectedResult ExpectedResult { get; }
 
-    public TestCase(Func<object>? targetActivator, object[] parameters, IMethodResult expectedResult)
+    public TestCase(Func<object>? targetActivator, object[] parameters, ITestExpectedResult expectedResult)
     {
         TargetActivator = targetActivator;
         

--- a/SuperUnit/Tests/TestParser.cs
+++ b/SuperUnit/Tests/TestParser.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using System.Security;
+using SuperUnit.Tests.Results.ExpectedResult.Return;
+using SuperUnit.Tests.Results.ExpectedResult.Thrown;
 using SuperUnit.Tests.Results.MethodResult;
 using SuperUnit.Tokeniser.Token;
 
@@ -252,7 +254,7 @@ public class TestParser
                         case Keyword.Expect:
                             Advance();
 
-                            cases.Add(new TestCase(currentTestTargetActivator, @params, new ReturnValueMethodResult(ParseValue())));
+                            cases.Add(new TestCase(currentTestTargetActivator, @params, new EqualityTestExpectedResult(ParseValue())));
                             break;
 
                         case Keyword.Throws:
@@ -260,12 +262,7 @@ public class TestParser
 
                             var thrownObject = ParseValue();
 
-                            if (thrownObject is not Type thrownException || !thrownException.IsAssignableTo(typeof(Exception)))
-                            {
-                                throw CreateParserException("Thrown Value is not a type which derives from Exception");
-                            }
-
-                            cases.Add(new TestCase(currentTestTargetActivator, @params, new ExceptionThrownMethodResult(thrownException)));
+                            cases.Add(new TestCase(currentTestTargetActivator, @params, new ExceptionThrownTestExpectedResult(thrownObject)));
 
                             break;
 


### PR DESCRIPTION
This PR seperates the expected result type and actual result types. This refactor allows for different types of checks (comparison based on type, based on == operator, based on public properties & fields). This refactor also shifts to using xunit.assert to handle test assertions instead of custom implementations. This means that a. assertion implementations are in a codebase that is actively maintained by .NET and b. Apache 2.0 license is included in Builds as they now contain the xunit dll.